### PR TITLE
fix: use all() instead of any() for AND semantics in deep search

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -469,11 +469,11 @@ fn search_deep(
             continue;
         }
 
-        // Verify query terms appear in extracted text
+        // Verify ALL query terms appear in extracted text (AND semantics)
         let text_lower = text.to_lowercase();
         if !query_terms
             .iter()
-            .any(|term| text_lower.contains(&term.to_lowercase()))
+            .all(|term| text_lower.contains(&term.to_lowercase()))
         {
             continue;
         }


### PR DESCRIPTION
## Summary

Fixes incorrect AND semantics in deep search.

## Problem

The CLI documents that query words are ANDed together, but the deep search verification was using `any()` which matched if ANY term was found in the message text.

## Fix

Changed `any()` to `all()` to require ALL query terms to match, consistent with the documented behavior.

## Before
```rust
if !query_terms.iter().any(|term| ...)
```

## After
```rust
if !query_terms.iter().all(|term| ...)
```