### PR TITLE
feat: add release workflow, badges, and crates.io metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,90 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: search-sessions-linux-x86_64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: search-sessions-linux-aarch64
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            artifact: search-sessions-macos-x86_64
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: search-sessions-macos-aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+
+      - name: Package
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czvf ../../../${{ matrix.artifact }}.tar.gz search-sessions
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create checksums
+        run: |
+          cd artifacts
+          for dir in */; do
+            cd "$dir"
+            sha256sum *.tar.gz > SHA256SUMS.txt
+            cat SHA256SUMS.txt
+            cd ..
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+          files: |
+            artifacts/**/*.tar.gz
+            artifacts/**/SHA256SUMS.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,11 @@ edition = "2024"
 description = "Fast CLI to search across Claude Code and OpenClaw session history"
 license = "MIT"
 repository = "https://github.com/sinzin91/search-sessions"
-keywords = ["claude", "openclaw", "search", "cli"]
+homepage = "https://github.com/sinzin91/search-sessions"
+readme = "README.md"
+keywords = ["claude", "openclaw", "search", "cli", "ai"]
 categories = ["command-line-utilities"]
+authors = ["Tenzin Wangdhen <sinzin91@gmail.com>"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # search-sessions
 
+[![CI](https://github.com/sinzin91/search-sessions/actions/workflows/ci.yml/badge.svg)](https://github.com/sinzin91/search-sessions/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/sinzin91/search-sessions)](https://github.com/sinzin91/search-sessions/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 Search across all your Claude Code **and OpenClaw** session history. Fast.
 
 ## What it does


### PR DESCRIPTION
## Summary

Adds everything needed to publish releases.

## Changes

### Release Workflow (`.github/workflows/release.yml`)
- Triggers on `v*` tags
- Builds binaries for:
  - Linux x86_64
  - Linux aarch64 (cross-compiled)
  - macOS x86_64
  - macOS aarch64 (Apple Silicon)
- Creates tar.gz archives with SHA256 checksums
- Auto-creates GitHub Release with all artifacts

### README Badges
- CI status badge
- Release version badge
- MIT license badge

### Cargo.toml
- Added `homepage`, `readme`, `authors` for crates.io
- Added `ai` keyword

## To Release

After merging:
```bash
git tag v0.1.0
git push origin v0.1.0
```

Then publish to crates.io:
```bash
cargo login <token>
cargo publish
```