### PR TITLE
release: v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## [0.3.1] - 2026-06-27
+
+### Changed
+
+- expand search-sessions SKILL.md — flags, perf hints, Obsidian (#22)
+
+### Fixed
+
+- resume command cd's to the session's project dir, not a transient cwd (#24)
+
 ## [0.3.0] - 2026-03-23
 
 ### Added
@@ -59,3 +70,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.1]: https://github.com/sinzin91/search-sessions/releases/tag/v0.1.1
 [0.1.0]: https://github.com/sinzin91/search-sessions/releases/tag/v0.1.0
 [0.3.0]: https://github.com/sinzin91/search-sessions/compare/v0.1.1...v0.3.0
+[0.3.1]: https://github.com/sinzin91/search-sessions/compare/v0.3.0...v0.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "search-sessions"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "search-sessions"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 description = "Fast CLI to search across Claude Code and OpenClaw session history"
 license = "MIT"


### PR DESCRIPTION
## Release v0.3.1

Bump 0.3.0 → 0.3.1 (patch). Opened manually — the cut-release workflow created and pushed the branch, but its `RELEASE_TOKEN` PAT lacks PR-create scope (`Resource not accessible by personal access token`); see run 28302106967.

**Changes (auto-generated CHANGELOG):**
- Changed: expand SKILL.md — flags, perf hints, Obsidian (#22)
- Fixed: resume command cd's to the session's project dir, not a transient cwd (#24)

**After merging:** tag-on-release-merge tags v0.3.1 → release.yml builds binaries, publishes to crates.io, and updates the Homebrew tap.