### PR TITLE
ci: fix duplicate SHA256SUMS.txt breaking release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,8 @@ jobs:
       - name: Create checksums
         run: |
           cd artifacts
-          for dir in */; do
-            cd "$dir"
-            sha256sum *.tar.gz > SHA256SUMS.txt
-            cat SHA256SUMS.txt
-            cd ..
-          done
+          sha256sum */*.tar.gz > SHA256SUMS.txt
+          cat SHA256SUMS.txt
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -87,7 +83,7 @@ jobs:
           generate_release_notes: true
           files: |
             artifacts/**/*.tar.gz
-            artifacts/**/SHA256SUMS.txt
+            artifacts/SHA256SUMS.txt
 
   publish-crate:
     name: Publish to crates.io


### PR DESCRIPTION
## Problem

The release workflow writes one `SHA256SUMS.txt` per artifact directory (4 total, same basename). GitHub release assets must have unique names, so `softprops/action-gh-release` 404'd on the duplicates and failed the `Create Release` job — which skipped `publish-crate` and `update-homebrew` (both `needs: release`). This is why v0.3.1 reached GitHub Releases but not crates.io or the Homebrew tap.

## Fix

Emit a single combined checksum file at the artifacts root (`sha256sum */*.tar.gz > SHA256SUMS.txt`) and upload just that one. Covers all four targets, no name collision.

After this merges, tag v0.3.1 will be re-cut to re-run the full publish pipeline.